### PR TITLE
fix GetImageSize bug of width and height mixed up

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -361,7 +361,7 @@ class GetImageSize:
             },
         }
     RETURN_TYPES = ("INT", "INT")
-    RETURN_NAMES = ("Width", "Height")
+    RETURN_NAMES = ("Height", "Width")
     FUNCTION = "get_image_size"
 
     CATEGORY = "Ultralytics/Utils"


### PR DESCRIPTION
image.shape[1] is Height and shape[2] is Width